### PR TITLE
Improved the way to use local variables

### DIFF
--- a/Simple-TOTP-Login.mrc
+++ b/Simple-TOTP-Login.mrc
@@ -1,7 +1,7 @@
 /undernet { 
-  set %loc_un YOUR_USERNAME
-  set %loc_pw YOUR_PASSWORD
-  if (!$1) { /server -m ix.undernet.org 6667 +x! %loc_un loc_pw $?="What is your TOTP code?" }
+  var %loc_un = YOUR_USERNAME
+  var %loc_pw = YOUR_PASSWORD
+  
+  if ($1 == $null) { /server -m ix.undernet.org 6667 +x! %loc_un loc_pw $?="What is your TOTP code?" }
   else { /server -m ix.undernet.org 6667 +x! %loc_un %loc_pw $1 }
-  unset %loc* 
 }


### PR DESCRIPTION
Changed to use /var instead of /set , because /set saves a global variables but /var is only a temporary.